### PR TITLE
Parentheses on \cite*

### DIFF
--- a/template/setrem.cls
+++ b/template/setrem.cls
@@ -35,7 +35,7 @@
 \RequirePackage{lastpage}
 \RequirePackage{indentfirst}
 \RequirePackage{template/setremdefs}
-\usepackage[square,sort,comma]{natbib}
+\usepackage[round,sort,comma]{natbib}
 \RequirePackage{setspace}
 \RequirePackage{titlesec}
 \RequirePackage{ragged2e}


### PR DESCRIPTION
Changed brackets into Parentheses on \cite* command